### PR TITLE
Mudança de axioma de ListFn

### DIFF
--- a/list.kif
+++ b/list.kif
@@ -32,11 +32,8 @@
 (equal (ListOrderFn (ListFn ?X) 1)
        ?X)
        
-(equal (ListOrderFn (ListFn ?X @ROW) (SucessorFn ?N))
-       (ListOrderFn (ListFn @ROW) ?N))
-
-(equal (ListOrderFn NullList ?N)
-       NullList)
+(equal (ListOrderFn (ConsFn ?X (ListFn ?Y @ROW)) (SucessorFn ?N))
+       (ListOrderFn (ListFn ?Y @ROW) ?N))
 
 
 (instance 0  NonnegativeInteger)

--- a/list.kif
+++ b/list.kif
@@ -14,6 +14,9 @@
 
 (equal (ListFn ?X ?Y)
        (ConsFn ?X (ListFn ?Y)))
+
+(equal (ListFn ?X ?Y ?Z)
+       (ConsFn ?X (ConsFn ?Y (ListFn ?Z)))
        
 (equal (ListFn ?X)
        (ConsFn ?X NullList))
@@ -31,10 +34,9 @@
 
 (equal (ListOrderFn (ListFn ?X) 1)
        ?X)
-       
-(equal (ListOrderFn (ConsFn ?X (ListFn ?Y @ROW)) (SucessorFn ?N))
-       (ListOrderFn (ListFn ?Y @ROW) ?N))
 
+(equal (ListOrderFn (ListFn ?X ?Y @ROW) (SucessorFn ?N))
+       (ListOrderFn (ListFn ?Y @ROW) ?N))
 
 (instance 0  NonnegativeInteger)
 (instance 1  PositiveInteger)


### PR DESCRIPTION
A partir do caso anterior, era possível chegar em (ListOrderFn NullList 0) a partir de (ListOrderFn (ListFn ?X) 1).
Agora, não é mais possível acessar elementos da lista vazia